### PR TITLE
feat: Allow custom cart item

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "printWidth": 80,
-  "bracketSpacing": true,
-  "singleQuote": true,
-  "trailingComma": "none",
-  "semi": false,
-  "arrowParens": "avoid",
-  "jsxBracketSameLine": true
-}

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ If a product record does not exist, you can instead pass a product object.
 ```json
 "customer": {  
   "name": "MULTI-VIBE 2",
-	"sku": "MULTI-VIBE-MK2",
-	"description": "Abstract, sculptural, refined and edgy with a modern twist.",
-	"quantity": 1,
-	"price": {
-		"amount": 50000
-	}
+  "sku": "MULTI-VIBE-MK2",
+  "description": "Abstract, sculptural, refined and edgy with a modern twist.",
+  "quantity": 1,
+  "price": {
+    "amount": 50000
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,4 +59,18 @@ If a customer record does not exist, you can instead pass a customer object.
 }
 ```
 
+If a product record does not exist, you can instead pass a product object.
+
+```json
+"customer": {  
+  "name": "MULTI-VIBE 2",
+	"sku": "MULTI-VIBE-MK2",
+	"description": "Abstract, sculptural, refined and edgy with a modern twist.",
+	"quantity": 1,
+	"price": {
+		"amount": 50000
+	}
+}
+```
+
 Learn more at the moltin [API reference](https://docs.moltin.com).

--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ Built with [Micro](https://github.com/zeit/micro) 🤩
 
 `npm run dev`
 
-Create a `now-secrets.json` at the project root with your moltin `client_id`.
+Create a `.env` at the project root with your moltin `client_id`.
 
-```json
-{
-  "@moltin-client-id": "your-client-id"
-}
+```dosini
+MOLTIN_CLIENT_ID=
 ```
 
 Both a moltin _and_ Stripe account are needed for this to function. Be sure that your [Stripe keys](https://stripe.com/docs/dashboard#api-keys) are attached to your moltin store. Learn more about that [here](https://docs.moltin.com/?bash#configuring-stripe).

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-require('now-env')
 const { json, send } = require('micro')
 const { router, post } = require('microrouter')
 const cors = require('micro-cors')()
@@ -27,7 +26,11 @@ module.exports = cors(
         )
 
         // Add the product to our cart
-        await moltin.Cart(cartId).AddProduct(product)
+        if (typeof product === 'object') {
+          await moltin.Cart(cartId).AddCustomItem(product)
+        } else {
+          await moltin.Cart(cartId).AddProduct(product)
+        }
 
         // Create an order from the cart (checkout)
         const { json: order } = await moltin
@@ -42,7 +45,7 @@ module.exports = cors(
         })
 
         // Success!
-        send(res, 201)
+        send(res, 201, { id: order.data.id })
       } catch ({ status, json }) {
         send(res, status, json.errors)
       }

--- a/now.json
+++ b/now.json
@@ -1,7 +1,0 @@
-{
-  "alias": "moltin-micro-checkout.now.sh",
-  "env": {
-    "NODE_ENV": "production",
-    "MOLTIN_CLIENT_ID": "@moltin-client-id"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "@moltin/sdk": {
-      "version": "github:ynnoj/js-sdk#f764865d802b6af955f91cd670aa8a7f8dfe8d02",
+      "version": "github:ynnoj/js-sdk#dfa552c695d2fe23fbad17b2b25b638a773311a3",
       "requires": {
         "cuid": "2.1.0",
         "es6-promise": "4.2.4",
@@ -2763,13 +2763,6 @@
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
-    },
-    "now-env": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/now-env/-/now-env-3.0.4.tgz",
-      "integrity":
-        "sha512-Z0YdDSrwkW2WvbGQVwc4Htf1dG+Kng+C7Qj9w9scQuQk8AEuJ5l62OiCuFAb9j2zBLe7eLHdz0T2gzOeZ73YwQ==",
-      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pretty-quick": "^1.4.1"
   },
   "prettier": {
-    "singleQuote": true,
+    "singleQuote": false,
     "semi": false,
     "jsxBracketSameLine": true
   },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,20 @@
   "devDependencies": {
     "husky": "^0.14.3",
     "micro-dev": "^2.2.2",
-    "now-env": "^3.0.4",
     "prettier": "^1.11.1",
     "pretty-quick": "^1.4.1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "semi": false,
+    "jsxBracketSameLine": true
+  },
+  "now": {
+    "alias": "moltin-micro-checkout.now.sh",
+    "dotenv": true,
+    "env": {
+      "NODE_ENV": "production",
+      "MOLTIN_CLIENT_ID": "@moltin-client-id"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pretty-quick": "^1.4.1"
   },
   "prettier": {
-    "singleQuote": false,
+    "singleQuote": true,
     "semi": false,
     "jsxBracketSameLine": true
   },


### PR DESCRIPTION
This PR allows you to do...

```json
{  
  "token": "tok_visa",
	"product": {
		"name": "iPhone",
		"sku": "iphone-x",
		"description": "My amazing iPhone",
		"quantity": 1,
		"price": {
			"amount": 50000
		}
	},
  "customer":"7b9678e4-a52a-469b-bfdd-6ad9b36d8dc4",
  "billing_address": {  
    "first_name": "Jonathan",
    "last_name": "Steele",
    "line_1": "2nd Floor British India House",
    "line_2": "15 Carliol Square",
    "city": "Newcastle Upon Tyne",
    "postcode": "NE1 6UF",
    "county": "Tyne & Wear",
    "country": "United Kingdom"
  }
}
```

I've also returned the order `id` in the body of the `201` response.

Also cleaned up the `.env` config so you no longer need to rely on the `now-env` dep. Create a `.env` and add your variables there, these will automatically be used on `now` deploy as `dotenv: true` exists inside `package.json`.